### PR TITLE
Migrate GXParser to typescript for easiest use with bundlers and node runtime.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "fast-xml-parser": "^3.12.19",
     "fit-file-parser": "^1.6.15",
     "geolib": "^3.0.4",
-    "gxparser": "^1.0.0",
     "lowpassf": "^0.5.0",
     "moving-median": "^1.0.0"
   },

--- a/src/events/adapters/importers/gpx/gx-parser.ts
+++ b/src/events/adapters/importers/gpx/gx-parser.ts
@@ -1,0 +1,46 @@
+export class GXParser {
+
+    constructor(xml: string, domParser: any = null) {
+        domParser = domParser || DOMParser;
+        const parser = new domParser();
+        const root = parser.parseFromString(xml, 'text/xml');
+
+        return this.parseChild(root.documentElement)
+    }
+
+    private parseChild(elm: any): any {
+        const attrs: any = {};
+        const attributes: any[] = elm.attributes;
+
+        for (const attribute of attributes) {
+            const attr: any = attribute;
+            if (attr && attr.value) {
+                attrs[attr.name] = attr.value
+            }
+        }
+
+        if (elm.childNodes) {
+
+            const children = elm.childNodes;
+            for (let i = 0; i < children.length; i++) {
+                const child = children[i];
+                const name = child.localName;
+                if (!name) {
+                    continue
+                }
+
+                if (!attrs[name]) {
+                    attrs[name] = []
+                }
+                attrs[name].push(this.parseChild(child))
+            }
+        }
+
+        if (Object.keys(attrs).length === 0) {
+            return elm.textContent
+        }
+        return attrs
+    }
+
+}
+

--- a/src/events/adapters/importers/gpx/importer.gpx.ts
+++ b/src/events/adapters/importers/gpx/importer.gpx.ts
@@ -7,8 +7,7 @@ import {ActivityInterface} from '../../../../activities/activity.interface';
 import {GPXSampleMapper} from './importer.gpx.mapper';
 import {isNumberOrString} from "../../../utilities/helpers";
 import {EventUtilities} from "../../../utilities/event.utilities";
-
-const GXParser = require('gxparser').GXParser;
+import {GXParser} from './gx-parser';
 
 export class EventImporterGPX {
 
@@ -16,7 +15,7 @@ export class EventImporterGPX {
 
     return new Promise((resolve, reject) => {
 
-      const parsedGPX: any = GXParser(gpx);
+      const parsedGPX: any = new GXParser(gpx, domParser);
       const track = parsedGPX.trk || parsedGPX.rte ;
 
       const activities: ActivityInterface[] = track.reduce((activities: ActivityInterface[], trackOrRoute: any) => {


### PR DESCRIPTION
I was unable to load properly the current GXParser within rollupjs to make it running on nodejs (should be also not simple through webpack). So this PR Migrates this "tiny" GXParser class as internal typescript class.

I can provide a "ts-gxparser" module on npmjs if your need. Let me know if you need this (the changes will be performed in this PR).

Still works in browser ofc